### PR TITLE
1-Pharo-nows-includes-shuffle-and-shuffleBy-by-default

### DIFF
--- a/src/CollectionExtensions/Collection.extension.st
+++ b/src/CollectionExtensions/Collection.extension.st
@@ -106,25 +106,6 @@ Collection >> selectAsSet: aBlock [
 ]
 
 { #category : #'*CollectionExtensions' }
-Collection >> shuffle [
-	"Swaps the receiver's elements at random."
-
-	self shuffle: (self size * self size log) asInteger
-]
-
-{ #category : #'*CollectionExtensions' }
-Collection >> shuffle: times [
-	"Swaps random elements of the receiver."
-
-	| size random |
-	size := self size.
-	random := Random new.
-	times timesRepeat: [ 
-		self swap: (random next * size) floor + 1 with: (random next * size) floor + 1 
-	].
-]
-
-{ #category : #'*CollectionExtensions' }
 Collection >> sortAscending: aBlockWithOneArgument [
 	^ self sorted: [ :x :y |
 		(aBlockWithOneArgument value: x) < (aBlockWithOneArgument value: y) ]

--- a/src/CollectionExtensions/SequenceableCollection.extension.st
+++ b/src/CollectionExtensions/SequenceableCollection.extension.st
@@ -99,6 +99,12 @@ SequenceableCollection >> runsSatisfying: testBlock do: enumerationBlock [
 ]
 
 { #category : #'*CollectionExtensions' }
+SequenceableCollection >> shuffle: times [
+	self deprecated: 'Use #shuffleBy: that is includes in Pharo by default.' transformWith: '`@receiver shuffle: `@statements' -> '`@receiver shuffleBy: `@statements'.
+	self shuffleBy: times
+]
+
+{ #category : #'*CollectionExtensions' }
 SequenceableCollection >> sliceFrom: startIndex [
 
 	"Answers a copy of a subset of the receiver, starting from element at start index 


### PR DESCRIPTION
Clean #shuffle and #shuffle:

Fixes #1